### PR TITLE
Feature/category markings

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ When dealing with unclassified information that has no limitations on disseminat
 
 CUI is separated into two types: CUI Basic and CUI Specified.
 
-*CUI Basic* is the standard type of CUI.
+**CUI Basic** is the standard type of CUI.
 
-*CUI Specified* contains special handling/dissemination requirements based on Category or Subcategory.  These handling requirements are based on laws, regulations, or government-wide policies.
+**CUI Specified** contains special handling/dissemination requirements based on Category or Subcategory.  These handling requirements are based on laws, regulations, or government-wide policies.
 
 When dealing with CUI Basic, the `categoryMarkings` attribute is optional, though recommended.
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The `categoryMarkings` attribute (Array[String]) is used to identify one or more
 Example values for `categoryMarkings` are:
 
 | Basic/Specified | Value | Category |
+| --------------- | ----- | -------- |
 | Specified | SP-CRITAN | Ammonium Nitrate |
 | Basic     | CVI       | Chemical-terrorism Vulnerability Information |
 | Specified | SP-CVI    | Chemical-terrorism Vulnerability Information |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Exstensible Markup Language (XML) is widely used within the DoD to share informa
 * [DoDM 5200.01, Volume 2 - DoD Information Security Program: Marking of Classified Information](http://www.dtic.mil/whs/directives/corres/pdf/520001_vol2.pdf)
 * [DoDM 5200.01, Volume 4 - DoD Information Security Program: Controlled Unclassified Information (CUI)](http://www.dtic.mil/whs/directives/corres/pdf/520001_vol4.pdf)
 * [Office of the Director of National Intelligence - Information Security Marking Metadata (ISM)](https://www.dni.gov/index.php/about/organization/chief-information-officer/information-security-marking-metadata)
+* [DoDI 5200.48 - Controlled Unclassified Information](https://www.esd.whs.mil/Portals/54/Documents/DD/issuances/dodi/520048p.PDF)
+* [CUI Marking Handbook](https://www.archives.gov/files/cui/documents/20161206-cui-marking-handbook-v1-1-20190524.pdf)
+* [CUI Categories](https://www.archives.gov/cui/registry/category-list)
 
 ## Overview
 
@@ -77,6 +80,18 @@ This sections describes which attributes of the ism object are required based on
 
 When dealing with unclassified information that has no limitations on dissemination, all ISM attributes are optional.  It is recommended however to include `version`, `classification`, and `ownerProducer` at the resource level.
 
+### Controlled Unclassified Information (CUI)
+
+CUI is separated into two types: CUI Basic and CUI Specified.
+
+*CUI Basic* is the standard type of CUI.
+
+*CUI Specified* contains special handling/dissemination requirements based on Category or Subcategory.  These handling requirements are based on laws, regulations, or government-wide policies.
+
+When dealing with CUI Basic, the `categoryMarkings` attribute is optional, though recommended.
+
+When dealing with CUI Specified, the `categoryMarkings` attribute is required.
+
 ### Classified Information
 
 When dealing with classified information, the `classification` and `ownerProducer` attributes are required.  All other attributes are optional.
@@ -101,12 +116,50 @@ The possible values for `classification` are:
 | C | CONFIDENTIAL |
 | S | SECRET |
 | TS | TOP SECRET |
+| CUI | CONTROLLED |
 | U | UNCLASSIFIED |
 
 **Example**
 ```json
   "classification": "U"
 ```
+
+### Category Markings
+
+The `categoryMarkings` attribute (Array[String]) is used to identify one or more CUI Categories or Subcategories.  This attribute is only used when `classification` is `CUI` and is required when dealing with CUI Specified.  When CUI Specified, the category is preceded with `SP-`.
+
+Example values for `categoryMarkings` are:
+
+| Basic/Specified | Value | Category |
+| Specified | SP-CRITAN | Ammonium Nitrate |
+| Basic     | CVI       | Chemical-terrorism Vulnerability Information |
+| Specified | SP-CVI    | Chemical-terrorism Vulnerability Information |
+| Specified | SP-CEII   | Critical Energy Infrastructure Information |
+| Basic     | EMGT      | Emergency Management |
+| Basic     | CRIT      | General Critical Infrastructure Information |
+| Basic     | ISVI      | Information Systems Vulnerability Information |
+| Basic     | PHYS      | Physical Security |
+| Specified | SP-PHYS   | Physical Security |
+| Specified | SP-PCII   | Protected Critical Infrastructure Information |
+| Basic     | SAFE      | SAFETY Act Information |
+| Specified | SP-TSCA   | Toxic Substances |
+| Basic     | WATER     | Water Assessments |
+
+**For a complete and up to date list of CUI Categories, visit ([CUI Categories](https://www.archives.gov/cui/registry/category-list))**
+
+**Example**
+```json
+  "categoryMarkings": [
+    "SP-CVI",
+    "CRIT"
+  ]  
+```
+
+When this attribute is used to generate banner or portion markings, the following rules apply:
+- Category Markings are required for CUI Specified
+- CUI Specified markings MUST precede CUI Basic Markings
+- CUI Category/Subcategory markings MUST be alphabetized within CUI type (Basic or Specified)
+- Alphabetized Specified CUI categories/subcategories MUST precede alphabetized Basic CUI categories/subcategories
 
 ### Owner Producer
 


### PR DESCRIPTION
@treyau21 I provided a subset of the CUI Categories list as an example and then provided a link to the full/up-to-date list.  Whether or not a category is Basic/Specified is determined by agencies/authorities, so I felt it best to link to the official list in case agencies are added to categories.  Let me know if this is ok or if you'd prefer I add in the entire list as it currently exists.